### PR TITLE
Feat. Specify how to get the time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+zig-*

--- a/src/rtt.zig
+++ b/src/rtt.zig
@@ -38,6 +38,18 @@ const Writer = std.io.Writer(c_uint, WriteError, struct {
 
 var default_log_writter: Writer = .{ .context = 0 };
 
+pub const Time = struct { seconds: u32, microseconds: u32 };
+const Getter = fn () Time;
+fn default_time_getter() Time {
+    return Time{ .seconds = 0, .microseconds = 0 };
+}
+
+var time_getter: *const Getter = default_time_getter;
+
+pub fn set_time_getter(comptime getter: Getter) void {
+    time_getter = getter;
+}
+
 pub fn logFn(
     comptime level: std.log.Level,
     comptime scope: @TypeOf(.EnumLiteral),
@@ -50,16 +62,6 @@ pub fn logFn(
         else => " (" ++ @tagName(scope) ++ "): ",
     };
 
-    // TODO
-    // const current_time = rp2040.time.get_time_since_boot();
-    // const seconds = current_time.to_us() / std.time.us_per_s;
-    // const microseconds = current_time.to_us() % std.time.us_per_s;
-
-    default_log_writter.print(prefix ++ format ++ "\r\n", .{ 0, 0 } ++ args) catch {};
+    const time = time_getter();
+    default_log_writter.print(prefix ++ format ++ "\r\n", .{ time.seconds, time.microseconds } ++ args) catch {};
 }
-
-// const current_time = rp2040.time.get_time_since_boot();
-// const seconds = current_time.to_us() / std.time.us_per_s;
-// const microseconds = current_time.to_us() % std.time.us_per_s;
-
-// (Writer{ .context = {} }).print(prefix ++ format ++ "\r\n", .{ seconds, microseconds } ++ args) catch {};


### PR DESCRIPTION
Thanks for this project. Hope you find this PR apealing :)

Allows user to configure an arbitrary way of getting the current time, or fallback to the current 0,0 tuple.

With these changes, i've gotten my code display the time as follows
```zig
fn time_getter() rtt.Time {
    //                                    v STM's HAL
    return rtt.Time{ .seconds = hal.HAL_GetTick(), .microseconds = 0 };
}

fn init() void {
    rtt.config_up_buffer(.{
        .index = 0,
        .name = "debug",
        .mode = .BlockIfFifoFull,
    });

    rtt.set_time_getter(time_getter);
}
```

Which logs
```
[502.000000] debug: Jumping to application
[502.000000] error (panic): Unimplemented.
```

--- 

Note that im a zig noob, and thus im not too aware of what the implications of the `comptime` argument are. My idea was to "make sure" we are keeping a reference to something that is stable, but could/should perhaps be done in a better way.

Maybe it would be better to use the  "does `root` have a function named `something`?"-pattern, but i already have a few of those thingies adding "noise" and i'd rather stop it and have a setter function instead 😅 